### PR TITLE
Initial implementation of caching for targets.

### DIFF
--- a/build/build_cache.odin
+++ b/build/build_cache.odin
@@ -1,0 +1,78 @@
+package build
+import "core:hash"
+import "core:os"
+import "core:fmt"
+import "core:mem"
+import "core:path/filepath"
+import "core:strings"
+import "core:strconv"
+import "core:slice"
+
+Build_Cache :: struct {
+	// Target name -> hash
+	checksums: map[string]u64,
+}
+
+// Maybe a dumb implementation? Who knows. It's fast enough.
+hash_target :: proc(target: ^Target) -> u64 {
+	hashes := make([dynamic]u64, 0, len(target.sources))
+	for source in target.sources {
+		if strings.contains_rune(source, '*') {
+			source := tabspath(target, source)
+
+			globbed_paths, err := filepath.glob(source)
+			fmt.assertf(err == nil, "Match error for glob path: %v", err)
+			for path in globbed_paths {
+				data, ok := os.read_entire_file(path)
+				fmt.assertf(ok, "Failed to read target source: %v", path)
+				append(&hashes, hash.crc64_xz(data))
+			}
+		} else {
+			data, ok := os.read_entire_file(tabspath(target, source))
+			fmt.assertf(ok, "Failed to read target source: %v", source)
+			append(&hashes, hash.crc64_xz(data))
+		}
+	}
+
+	return hash.crc64_xz(mem.slice_to_bytes(hashes[:]))
+}
+
+read_build_cache :: proc() {
+	cwd := os.get_current_directory()
+	path := filepath.join({cwd, ".obuild"})
+
+	file, ok := os.read_entire_file(path)
+	if !ok do return
+
+	line_iter := string(file)
+	for line in strings.split_lines_iterator(&line_iter) {
+		splits := strings.split(line, "=")
+		// Invalid line, skip.
+		if len(splits) != 2 do continue
+
+		name := splits[0]
+		parsed_length: int
+		hash, parse_ok := strconv.parse_u64(splits[1], 10, &parsed_length)
+		if !parse_ok do continue
+
+		_build_cache.checksums[name] = hash
+	}
+}
+
+write_build_cache :: proc() {
+	cwd := os.get_current_directory()
+	path := filepath.join({cwd, ".obuild"})
+
+	file, ok := os.open(path, os.O_CREATE | os.O_WRONLY | os.O_TRUNC)
+	assert(ok == 0, "Failed to open cache file for reading")
+	defer os.close(file)
+
+	names, _ := slice.map_keys(_build_cache.checksums)
+	slice.sort(names)
+
+	for name in names {
+		hash := _build_cache.checksums[name]
+		if hash == 0 do continue
+		os.write_string(file, fmt.tprintf("%v=%v\n", name, hash))
+	}
+}

--- a/build/cli.odin
+++ b/build/cli.odin
@@ -13,7 +13,6 @@ import "core:unicode"
 import "core:strconv"
 import "core:intrinsics"
 
-
 Flag_Arg :: struct { // -flag:key=val
 	flag: string,
 	key: string,
@@ -119,9 +118,13 @@ print_general_help :: proc(info: Cli_Info) {
 	}
 }
 
-run_cli :: proc(info: Cli_Info, cli_args: []string) -> bool {
+run_cli :: proc(info: Cli_Info, cli_args: []string, loc := #caller_location) -> bool {
 	runtime.DEFAULT_TEMP_ALLOCATOR_TEMP_GUARD()
+	_project_directory = filepath.join({loc.file_path, "../../"})
 	args, err := parse_args(cli_args, context.temp_allocator) // cli_args[0] should be the executable
+
+	read_build_cache()
+
 	target_names_from_args := make_dynamic_array_len_cap([dynamic]string, 0, len(info.project.targets), context.temp_allocator) // This is not fully correct right now
 	filtered_args_by_mode := make([dynamic]Arg, context.temp_allocator)
 	current_mode: Maybe(Run_Mode)
@@ -177,6 +180,8 @@ run_cli :: proc(info: Cli_Info, cli_args: []string) -> bool {
 			} 
 		}
 	}
+
+	write_build_cache()
 
 	return true
 }

--- a/build/globals.odin
+++ b/build/globals.odin
@@ -110,3 +110,7 @@ _timings_mode_to_arg := [Timings_Mode]string {
 	.Basic    = "-show-timings",
 	.Advanced = "-show-more-timings",
 }
+
+_build_cache: Build_Cache
+
+_project_directory: string


### PR DESCRIPTION
Initial implementation of the caching stuff we talked about. I'm not sure if anything is missing/wrong but i wanted another set of eyes, so i made this PR.

Two new fields are added to `Target`:
* `sources`: Defines a list of sources. They can be any file. Before running a target, all of the files in this list are hashed individually and then all of the hashes are hashed as well to get one single hash.
* `outputs`: This is another list of files. They can also be anything. Before running a target, we check if any of these file are missing and if so, continue with running the target. This can be used to ensure that a target is re-run if any exe's or dll's it depends on were somehow deleted.

At the end of the program, we through a map of `Target` -> `hash` and store it in a .obuild file at the current working directory. This is the only thing i find kind of iffy. Since there is no "project" directory, i assume that it is the parent directory of where `run_cli` is invoked. This could definitely be improved.